### PR TITLE
Manually exclude IDs from tag

### DIFF
--- a/src/Tags/StatamicCuratedCollection.php
+++ b/src/Tags/StatamicCuratedCollection.php
@@ -54,6 +54,12 @@ class StatamicCuratedCollection extends Tags
         if ($ids = $this->deduplicateApply()) {
             $query->whereNotIn('entry_id', $ids);
         }
+        if ($ids = $this->params['id:not_in'] ?? null) {
+            if (is_string($ids)) {
+                $ids = explode('|', $ids);
+            }
+            $query->whereNotIn('entry_id', $ids);
+        }
 
         $results = $this->results($query);
 

--- a/src/Tags/StatamicCuratedCollection.php
+++ b/src/Tags/StatamicCuratedCollection.php
@@ -54,7 +54,7 @@ class StatamicCuratedCollection extends Tags
         if ($ids = $this->deduplicateApply()) {
             $query->whereNotIn('entry_id', $ids);
         }
-        if ($ids = $this->params['id:not_in'] ?? null) {
+        if ($ids = $this->params->get('id:not_in')) {
             if (is_string($ids)) {
                 $ids = explode('|', $ids);
             }


### PR DESCRIPTION
Adds the ability to manually exclude IDs from the curated collections tag, separately (or in addition to) the exclusions that that deduplicate applies:

```antlers
{{ curated_collection:forside id:not_in="8da81e3d-c2d0-48ac-8f77-f30cc9a57dae" }}
```