### PR TITLE
Collection entry limits

### DIFF
--- a/lang/da/configure.php
+++ b/lang/da/configure.php
@@ -6,7 +6,7 @@ return [
     'handle_instructions' => 'Used to reference this curated collection on the frontend. It\'s non-trivial to change later.',
     'blueprint_instructions' => 'Edit the blueprint to control the fields available for each curated entry.',
     'collections_instructions' => 'You must select at least one collection to curate.',
-    'max_entries_instructions' => 'The maximum number of entries that can be added to this curated collection.',
+    'max_items' => 'The maximum number of entries that can be added to this curated collection.',
     'fallback_collection_instructions' => 'You must select at least one collection to curate.',
     'fallback_sort_field' => 'The field to sort by in the fallback collection.',
     'automation_instructions' => 'Enable automation for publishing and unpublishing entries in the curated collection.',

--- a/lang/en/configure.php
+++ b/lang/en/configure.php
@@ -7,7 +7,7 @@ return [
     'blueprint_instructions' => 'Edit the blueprint to control the fields available for each curated entry.',
     'collections_instructions' => 'You must select at least one collection to curate.',
     'display_form' => 'Force the form to be displayed when adding entries. Any required field in the blueprint will enforce the form to show.',
-    'max_entries_instructions' => 'The maximum number of entries that can be added to this curated collection.',
+    'max_items' => 'The maximum number of entries that can be added to this curated collection.',
     'fallback_collection_instructions' => 'You must select at least one collection to curate.',
     'fallback_sort_field' => 'The field to sort by in the fallback collection.',
     'automation_instructions' => 'Enable automation for publishing and unpublishing entries in the curated collection.',

--- a/src/Http/Controllers/CP/ApiEntriesController.php
+++ b/src/Http/Controllers/CP/ApiEntriesController.php
@@ -107,6 +107,17 @@ class ApiEntriesController
             $curatedCollectionEntry->setPosition($request->input('order'));
         }
 
+        // Remove entries if we exceed max items
+        if ($curatedCollection->max_items && $curatedCollection->entries()->count() > $curatedCollection->max_items) {
+            CuratedCollectionEntry::query()
+                ->where('curated_collection_id', $curatedCollection->id)
+                ->ordered()
+                ->get()
+                ->skip($curatedCollection->max_items)
+                ->each
+                ->delete();
+        }
+
         return new CuratedCollectionEntryResource($curatedCollectionEntry);
     }
 

--- a/src/Http/Controllers/CP/CuratedCollectionController.php
+++ b/src/Http/Controllers/CP/CuratedCollectionController.php
@@ -189,6 +189,12 @@ class CuratedCollectionController extends CpController
                         'type' => 'toggle',
                         'default' => true,
                     ],
+                    'max_items' => [
+                        'display' => __('Max items'),
+                        'instructions' => __('statamic-curated-collections::configure.max_items'),
+                        'type' => 'integer',
+                        'default' => 100,
+                    ],
                 ],
             ],
             'automation' => [

--- a/src/Http/Controllers/CP/CuratedCollectionController.php
+++ b/src/Http/Controllers/CP/CuratedCollectionController.php
@@ -190,7 +190,7 @@ class CuratedCollectionController extends CpController
                         'default' => true,
                     ],
                     'max_items' => [
-                        'display' => __('Max items'),
+                        'display' => __('Max entries'),
                         'instructions' => __('statamic-curated-collections::configure.max_items'),
                         'type' => 'integer',
                         'default' => 100,

--- a/src/Models/CuratedCollection.php
+++ b/src/Models/CuratedCollection.php
@@ -21,6 +21,7 @@ class CuratedCollection extends Model
         'site',
         'collections',
         'display_form',
+        'max_items',
         'fallback_collection',
         'fallback_sort_field',
         'fallback_sort_direction',


### PR DESCRIPTION
Adds a max entries option to the collection config. If the number of entries exceeds that number when adding a new entry the extras are removed.