### PR TITLE
Add entry priority dates

### DIFF
--- a/database/migrations/2025_04_15_110000_add_priority_date_column_to_entries_table.php
+++ b/database/migrations/2025_04_15_110000_add_priority_date_column_to_entries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('curated_collection_entries', function (Blueprint $table) {
+            $table->timestamp('priority_date')->nullable()->after('unpublish_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('curated_collection_entries', function (Blueprint $table) {
+            $table->dropColumn('priority_date');
+        });
+    }
+};

--- a/src/Http/Controllers/CP/ApiEntriesController.php
+++ b/src/Http/Controllers/CP/ApiEntriesController.php
@@ -62,7 +62,7 @@ class ApiEntriesController
         $curatedCollectionEntry = CuratedCollectionEntry::make();
         $curatedCollectionEntry->curatedCollection()->associate($curatedCollection);
         $curatedCollectionEntry->entry($entry);
-        $curatedCollectionEntry->data(collect($data)->except(['curated_collection', 'entry', 'order', 'unpublish_at']));
+        $curatedCollectionEntry->data(collect($data)->except(['curated_collection', 'entry', 'order', 'unpublish_at', 'priority_date']));
         $curatedCollectionEntry->collection($entry->collection());
 
         if ($entry->status() === 'published') {
@@ -78,6 +78,10 @@ class ApiEntriesController
 
             if (isset($unpublishAt)) {
                 $curatedCollectionEntry->unpublishAt($unpublishAt);
+            }
+
+            if ($data['priority_date']) {
+                $curatedCollectionEntry->priorityDate($data['priority_date']);
             }
 
             $curatedCollectionEntry->status('published');
@@ -146,7 +150,7 @@ class ApiEntriesController
         $fields->validate();
         $data = $fields->process()->values()->all();
 
-        $curatedCollectionEntry->data(collect($data)->except(['curated_collection', 'entry', 'order', 'unpublish_at']));
+        $curatedCollectionEntry->data(collect($data)->except(['curated_collection', 'entry', 'order', 'unpublish_at', 'priority_date']));
 
         if ($entry->status() === 'published') {
 
@@ -165,6 +169,10 @@ class ApiEntriesController
         // set the unpublish time absolute
         if ($data['unpublish_at']) {
             $curatedCollectionEntry->unpublishAt($data['unpublish_at']);
+        }
+        
+        if ($data['priority_date']) {
+            $curatedCollectionEntry->priorityDate($data['priority_date']);
         }
 
         $curatedCollectionEntry->save();

--- a/src/Http/Controllers/CP/ApiEntriesController.php
+++ b/src/Http/Controllers/CP/ApiEntriesController.php
@@ -170,7 +170,7 @@ class ApiEntriesController
         if ($data['unpublish_at']) {
             $curatedCollectionEntry->unpublishAt($data['unpublish_at']);
         }
-        
+
         if ($data['priority_date']) {
             $curatedCollectionEntry->priorityDate($data['priority_date']);
         }

--- a/src/Http/Resources/CuratedCollectionEntryEditResource.php
+++ b/src/Http/Resources/CuratedCollectionEntryEditResource.php
@@ -22,7 +22,7 @@ class CuratedCollectionEntryEditResource extends JsonResource
 
         if ($this->resource->priority_date) {
             $date = Carbon::parse($this->resource->priority_date);
-        } else if ($entry->published_date) {
+        } elseif ($entry->published_date) {
             $date = $entry->published_date;
         } else {
             $date = $entry->date;

--- a/src/Http/Resources/CuratedCollectionEntryEditResource.php
+++ b/src/Http/Resources/CuratedCollectionEntryEditResource.php
@@ -2,6 +2,7 @@
 
 namespace Tv2regionerne\StatamicCuratedCollection\Http\Resources;
 
+use Carbon\Carbon;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class CuratedCollectionEntryEditResource extends JsonResource
@@ -18,7 +19,15 @@ class CuratedCollectionEntryEditResource extends JsonResource
     public function toArray($request)
     {
         $entry = $this->resource->entry();
-        $entry_published = $entry->published && (! $entry->published_date || $entry->published_date->isPast());
+
+        if ($this->resource->priority_date) {
+            $date = Carbon::parse($this->resource->priority_date);
+        } else if ($entry->published_date) {
+            $date = $entry->published_date;
+        } else {
+            $date = $entry->date;
+        }
+        $entry_published = $entry->published && (! $date || $date->isPast());
 
         $data = json_decode(json_encode($this->data), true) ?? [];
         $values = array_merge($data, [
@@ -28,6 +37,7 @@ class CuratedCollectionEntryEditResource extends JsonResource
             'collection' => $this->collection,
             'order' => $this->order_column,
             'unpublish_at' => $this->unpublish_at,
+            'priority_date' => $this->priority_date,
             'entry_published' => $entry_published,
         ]);
 

--- a/src/Http/Resources/CuratedCollectionEntryResource.php
+++ b/src/Http/Resources/CuratedCollectionEntryResource.php
@@ -31,6 +31,7 @@ class CuratedCollectionEntryResource extends JsonResource
             'expiration_time' => $this->expiration_time,
             'data' => $this->data,
             'unpublish_at' => $this->unpublish_at,
+            'priority_date' => $this->priority_date,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/src/Models/CuratedCollection.php
+++ b/src/Models/CuratedCollection.php
@@ -62,18 +62,6 @@ class CuratedCollection extends Model
                 'type' => 'collections',
             ], null, true);
 
-            $blueprint->ensureField('unpublish_at', [
-                'type' => 'date',
-                'display' => __('Fjern fra listen den'),
-                'instructions' => __('Indlægget fjernes automatisk fra listen på denne dato'),
-                'time_enabled' => true,
-                'format' => 'c',
-                'width' => 50,
-                'validate' => [
-                    'nullable',
-                ],
-            ], null, true);
-
             $blueprint->ensureField('published', [
                 'visibility' => 'hidden',
                 'type' => 'toggle',
@@ -84,6 +72,33 @@ class CuratedCollection extends Model
                 'visibility' => 'hidden',
                 'type' => 'toggle',
                 'width' => 50,
+            ], null, true);
+
+            $blueprint->ensureField('priority_date', [
+                'type' => 'date',
+                'display' => __('Priority date'),
+                'instructions' => __('Priority date for this entry'),
+                'time_enabled' => true,
+                'format' => 'c',
+                'width' => 50,
+                'if' => [
+                    'entry_published' => true,
+                ],
+                'validate' => [
+                    'nullable',
+                ],
+            ], null, true);
+
+            $blueprint->ensureField('unpublish_at', [
+                'type' => 'date',
+                'display' => __('Fjern fra listen den'),
+                'instructions' => __('Indlægget fjernes automatisk fra listen på denne dato'),
+                'time_enabled' => true,
+                'format' => 'c',
+                'width' => 50,
+                'validate' => [
+                    'nullable',
+                ],
             ], null, true);
 
             $blueprint->ensureField('expiration_time', [

--- a/src/Models/CuratedCollectionEntry.php
+++ b/src/Models/CuratedCollectionEntry.php
@@ -31,6 +31,7 @@ class CuratedCollectionEntry extends Model
         'expiration_time',
         'status',
         'unpublish_at',
+        'priority_date',
     ];
 
     protected $casts = [
@@ -110,6 +111,22 @@ class CuratedCollectionEntry extends Model
             return $this->expiration_time;
         }
         $this->expiration_time = $expirationTime;
+
+        return $this;
+    }
+
+    public function priorityDate($priorityDate = null)
+    {
+        if (! $priorityDate) {
+            return $this->priority_date;
+        }
+        // Handle the statamic date/time array
+        if (is_array($priorityDate)) {
+            $this->priority_date = Carbon::make($priorityDate['date'].' '.$priorityDate['time']);
+
+            return $this;
+        }
+        $this->priority_date = $priorityDate;
 
         return $this;
     }

--- a/src/Tags/StatamicCuratedCollection.php
+++ b/src/Tags/StatamicCuratedCollection.php
@@ -52,7 +52,7 @@ class StatamicCuratedCollection extends Tags
             ->where('status', 'published')
             ->where(function ($query) {
                 $query->whereDate('priority_date', '<=', now())
-                      ->orWhereNull('priority_date');
+                    ->orWhereNull('priority_date');
             })
             ->ordered();
 

--- a/src/Tags/StatamicCuratedCollection.php
+++ b/src/Tags/StatamicCuratedCollection.php
@@ -51,7 +51,7 @@ class StatamicCuratedCollection extends Tags
             ->where('curated_collection_id', $curatedCollection->id)
             ->where('status', 'published')
             ->where(function ($query) {
-                $query->whereDate('priority_date', '<=', now())
+                $query->whereDate('priority_date', '<', now())
                     ->orWhereNull('priority_date');
             })
             ->ordered();

--- a/src/Tags/StatamicCuratedCollection.php
+++ b/src/Tags/StatamicCuratedCollection.php
@@ -50,6 +50,10 @@ class StatamicCuratedCollection extends Tags
         $query = CuratedCollectionEntry::query()
             ->where('curated_collection_id', $curatedCollection->id)
             ->where('status', 'published')
+            ->where(function ($query) {
+                $query->whereDate('priority_date', '<=', now())
+                      ->orWhereNull('priority_date');
+            })
             ->ordered();
 
         $ids = $this->params->get('id:not_in', []);


### PR DESCRIPTION
Adds a new `priority_date` field to curated collection entries. If this is set it affects the behaviour in the following ways:

1. It's the date used to check whether the entry should be considered published when toggling the field visibility in the CP.
    - See https://github.com/tv2regionerne/statamic-curated-collections/pull/51/files#diff-e07f90c5d5df24f01a44c4bcb1d5de0ff01602323350714f12d3da1340a68aacR23
3. Entries with a future priority date are not included in the tag query.
    - See https://github.com/tv2regionerne/statamic-curated-collections/pull/51/files#diff-ed008136bb4f743e849e17114bbff5bb49a6956230c0526ada94ed0e6f460b0aR53

In addition to point 1 the normal Statamic `date` field has been added as a fallback if no `priority_date` or `published_date` is set, as discussed here: https://github.com/tv2regionerne/statamic-issues/issues/26#issuecomment-2703283931